### PR TITLE
Use email address from user account instead of user ID for autologin

### DIFF
--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -31,7 +31,7 @@ if (@file_exists(__DIR__.'/app/index.php'))
 
 		if (OCP\Config::getAppValue('rainloop', 'rainloop-autologin', false))
 		{
-			$sEmail = $sUser;
+			$sEmail = OCP\Config::getUserValue($sUser, 'settings', 'email');
 			$sEncodedPassword = OCP\Config::getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else
@@ -40,7 +40,7 @@ if (@file_exists(__DIR__.'/app/index.php'))
 			$sEncodedPassword = OCP\Config::getUserValue($sUser, 'rainloop', 'rainloop-password', '');
 		}
 
-		$sDecodedPassword = OC_RainLoop_Helper::decodePassword($sEncodedPassword, md5($sEmail));
+		$sDecodedPassword = OC_RainLoop_Helper::decodePassword($sEncodedPassword, md5($sUser));
 
 		$_ENV['___rainloop_owncloud_email'] = $sEmail;
 		$_ENV['___rainloop_owncloud_password'] = $sDecodedPassword;


### PR DESCRIPTION
As described in #11, this will pull the email address setting for the user account instead of using the ID field.

It's useful for other external user data sources where the ID is not the same as the email address, e..g. LDAP