### PR TITLE
Work around UID issue with LDAP users

### DIFF
--- a/rainloop/admin.php
+++ b/rainloop/admin.php
@@ -15,4 +15,5 @@ OCP\Util::addScript('rainloop', 'admin');
 $oTemplate = new OCP\Template('rainloop', 'admin-local');
 $oTemplate->assign('rainloop-admin-panel-link', OC_RainLoop_Helper::getAppUrl().'?admin');
 $oTemplate->assign('rainloop-autologin', \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false));
+$oTemplate->assign('rainloop-useemail', \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-useemail', false));
 return $oTemplate->fetchPage();

--- a/rainloop/ajax/admin.php
+++ b/rainloop/ajax/admin.php
@@ -21,6 +21,9 @@ if (isset($_POST['appname']) &&	'rainloop' === $_POST['appname'])
 	\OC::$server->getConfig()->setAppValue('rainloop', 'rainloop-autologin', isset($_POST['rainloop-autologin']) ?
 		'1' === $_POST['rainloop-autologin'] : false);
 
+	\OC::$server->getConfig()->setAppValue('rainloop', 'rainloop-useemail', isset($_POST['rainloop-useemail']) ?
+		'1' === $_POST['rainloop-useemail'] : false);
+
 	$bAutologin = \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false);
 }
 else

--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -39,7 +39,15 @@ if (@file_exists(__DIR__.'/app/index.php'))
 
 		if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false))
 		{
-			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-email', '');
+			if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-useemail', false))
+			{
+				$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'settings', 'email', $sUser);
+			}
+			else
+			{
+				$sEmail = $sUser;
+			}
+
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else

--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -39,7 +39,7 @@ if (@file_exists(__DIR__.'/app/index.php'))
 
 		if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false))
 		{
-			$sEmail = $sUser;
+			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-email', '');
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else

--- a/rainloop/lib/RainLoopHelper.php
+++ b/rainloop/lib/RainLoopHelper.php
@@ -29,6 +29,7 @@ class OC_RainLoop_Helper
 	public static function getSsoHash($sPath, $sEmail, $sPassword)
 	{
 		$SsoHash = '';
+
 		$sPath = rtrim(trim($sPath), '\\/').'/index.php';
 		if (file_exists($sPath))
 		{
@@ -183,22 +184,15 @@ class OC_RainLoop_Helper
 	 */
 	public static function login($aParams)
 	{
-		if (isset($aParams['uid'], $aParams['password'], $_POST['user']))
+		if (isset($aParams['uid'], $aParams['password']))
 		{
-			$sUID = $aParams['uid'];
-			$sUser = $_POST['user'];
+			$sUser = $aParams['uid'];
 
 			$sEmail = $sUser;
 			$sPassword = $aParams['password'];
 
-			$setEmail = \OC::$server->getConfig()->setUserValue($sUID, 'rainloop', 'rainloop-autologin-email',
-				$sEmail);
-
-			
-			$setPassword = \OC::$server->getConfig()->setUserValue($sUID, 'rainloop', 'rainloop-autologin-password',
-				self::encodePassword($sPassword, md5($sUID)));
-
-			return ($setEmail && $setPassword);
+			return \OC::$server->getConfig()->setUserValue($sUser, 'rainloop', 'rainloop-autologin-password',
+				self::encodePassword($sPassword, md5($sEmail)));
 		}
 
 		return false;
@@ -206,9 +200,6 @@ class OC_RainLoop_Helper
 
 	public static function logout()
 	{
-		\OC::$server->getConfig()->setUserValue(
-			OCP\User::getUser(), 'rainloop', 'rainloop-autologin-email', '');
-		
 		\OC::$server->getConfig()->setUserValue(
 			OCP\User::getUser(), 'rainloop', 'rainloop-autologin-password', '');
 

--- a/rainloop/lib/RainLoopHelper.php
+++ b/rainloop/lib/RainLoopHelper.php
@@ -29,7 +29,6 @@ class OC_RainLoop_Helper
 	public static function getSsoHash($sPath, $sEmail, $sPassword)
 	{
 		$SsoHash = '';
-
 		$sPath = rtrim(trim($sPath), '\\/').'/index.php';
 		if (file_exists($sPath))
 		{
@@ -184,15 +183,22 @@ class OC_RainLoop_Helper
 	 */
 	public static function login($aParams)
 	{
-		if (isset($aParams['uid'], $aParams['password']))
+		if (isset($aParams['uid'], $aParams['password'], $_POST['user']))
 		{
-			$sUser = $aParams['uid'];
+			$sUID = $aParams['uid'];
+			$sUser = $_POST['user'];
 
 			$sEmail = $sUser;
 			$sPassword = $aParams['password'];
 
-			return \OC::$server->getConfig()->setUserValue($sUser, 'rainloop', 'rainloop-autologin-password',
-				self::encodePassword($sPassword, md5($sEmail)));
+			$setEmail = \OC::$server->getConfig()->setUserValue($sUID, 'rainloop', 'rainloop-autologin-email',
+				$sEmail);
+
+			
+			$setPassword = \OC::$server->getConfig()->setUserValue($sUID, 'rainloop', 'rainloop-autologin-password',
+				self::encodePassword($sPassword, md5($sUID)));
+
+			return ($setEmail && $setPassword);
 		}
 
 		return false;
@@ -200,6 +206,9 @@ class OC_RainLoop_Helper
 
 	public static function logout()
 	{
+		\OC::$server->getConfig()->setUserValue(
+			OCP\User::getUser(), 'rainloop', 'rainloop-autologin-email', '');
+		
 		\OC::$server->getConfig()->setUserValue(
 			OCP\User::getUser(), 'rainloop', 'rainloop-autologin-password', '');
 

--- a/rainloop/templates/admin-local.php
+++ b/rainloop/templates/admin-local.php
@@ -5,7 +5,6 @@
 
 		<fieldset class="personalblock">
 			<h2><?php p($l->t('RainLoop Webmail')); ?></h2>
-			<br />
 			<?php if ($_['rainloop-admin-panel-link']): ?>
 			<p>
 				<a href="<?php echo $_['rainloop-admin-panel-link'] ?>" target="_blank" style="text-decoration: underline">
@@ -15,14 +14,23 @@
 			<br />
 			<?php endif; ?>
 			<p>
-				<input type="checkbox" id="rainloop-autologin" id="rainloop-autologin" name="rainloop-autologin" value="1" <?php if ($_['rainloop-autologin']): ?>checked="checked"<?php endif; ?> />
+				<input type="checkbox" id="rainloop-autologin" class="checkbox" name="rainloop-autologin" value="1" <?php if ($_['rainloop-autologin']): ?>checked="checked"<?php endif; ?> />
 				<label for="rainloop-autologin">
 					<?php p($l->t('Automatically login with ownCloud user credentials')); ?>
 				</label>
-				<br />
-				<br />
+			</p>
+			<p>
+				<input type="checkbox" id="rainloop-useemail" class="checkbox" name="rainloop-useemail" value="1" <?php if ($_['rainloop-useemail']): ?>checked="checked"<?php endif; ?> />
+				<label for="rainloop-useemail">
+					<?php p($l->t('Automatically login with the email address from the user profile')); ?>
+				</label> 
+			</p>
+			<br>
+			<p>
 				<input type="button" id="rainloop-save-button" name="rainloop-save-button" value="<?php p($l->t('Save')); ?>" />
-				&nbsp;&nbsp;<span class="rainloop-result-desc"></span>
+			</p>
+			<p>
+				<span class="rainloop-result-desc"></span>
 			</p>
 		</fieldset>
 	</form>


### PR DESCRIPTION
There is a problem with the Rainloop plugin when using automated log in and LDAP. By default, the uid known to NC is the UUID of the LDAP DN for the user, not the the uid or other property used for the username or email address to login with.

On a new NC installation it would be possible to change that behavior in NC. But for existing installations this would be very hard. So, NC had the LDAP UUID as uid for the user and it's completely useless for automated login into Rainloop.

I have no idea if there is another place to get the 'username' from that would be more graceful. In the PR I used the raw post variable. I usually don't do any NC development so I don't know if there is a more elegant approach. I also don't know if this breaks possible other authentication methods that I'm not aware of.

Edit: after reading #11, I was convinced that this would be a far more elegant approach. I made changes accordingly.