### PR TITLE
Compatibility to NC17 #1

### DIFF
--- a/rainloop/index.php
+++ b/rainloop/index.php
@@ -9,7 +9,6 @@
  */
 
 OCP\User::checkLoggedIn();
-OCP\App::checkAppEnabled('rainloop');
 \OC::$server->getNavigationManager()->setActiveEntry('rainloop_index');
 
 // Load the empty file ../css/style.css, that's needed to allow theming of


### PR DESCRIPTION
OCP\App::checkAppEnabled() is deprecated since NC9
(@deprecated 9.0.0 ownCloud core will handle disabled apps and redirects to valid URLs)