### PR TITLE
Compatibility NC17 #2

### DIFF
--- a/rainloop/personal.php
+++ b/rainloop/personal.php
@@ -9,7 +9,6 @@
  */
 
 OCP\User::checkLoggedIn();
-OCP\App::checkAppEnabled('rainloop');
 
 OCP\Util::addScript('rainloop', 'personal');
 


### PR DESCRIPTION
OCP\App::checkAppEnabled() is deprecated since NC9
(@deprecated 9.0.0 ownCloud core will handle disabled apps and redirects to valid URLs)