### PR TITLE
Fix issue with autologin with LDAP and user email 

### DIFF
--- a/rainloop/admin.php
+++ b/rainloop/admin.php
@@ -15,4 +15,5 @@ OCP\Util::addScript('rainloop', 'admin');
 $oTemplate = new OCP\Template('rainloop', 'admin-local');
 $oTemplate->assign('rainloop-admin-panel-link', OC_RainLoop_Helper::getAppUrl().'?admin');
 $oTemplate->assign('rainloop-autologin', \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false));
+$oTemplate->assign('rainloop-autologin-with-email', \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin-with-email', false));
 return $oTemplate->fetchPage();

--- a/rainloop/ajax/admin.php
+++ b/rainloop/ajax/admin.php
@@ -20,6 +20,8 @@ if (isset($_POST['appname']) &&	'rainloop' === $_POST['appname'])
 {
 	\OC::$server->getConfig()->setAppValue('rainloop', 'rainloop-autologin', isset($_POST['rainloop-autologin']) ?
 		'1' === $_POST['rainloop-autologin'] : false);
+	\OC::$server->getConfig()->setAppValue('rainloop', 'rainloop-autologin-with-email', isset($_POST['rainloop-autologin']) ?
+		'2' === $_POST['rainloop-autologin'] : false);
 
 	$bAutologin = \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false);
 }

--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -36,19 +36,28 @@ if (@file_exists(__DIR__.'/app/index.php'))
 		$sEncodedPassword = '';
 
 		$sUser = OCP\User::getUser();
+    $sPasswordSalt = '';
 
 		if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false))
 		{
 			$sEmail = $sUser;
+      $sPasswordSalt = $sUser;
+			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
+		}
+		else if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin-with-email', false))
+		{
+			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'settings', 'email','');
+      $sPasswordSalt = $sUser;
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else
 		{
 			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-email', '');
+      $sPasswordSalt = $sEmail
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-password', '');
 		}
 
-		$sDecodedPassword = OC_RainLoop_Helper::decodePassword($sEncodedPassword, md5($sEmail));
+		$sDecodedPassword = OC_RainLoop_Helper::decodePassword($sEncodedPassword, md5($sPasswordSalt));
 
 		$_ENV['___rainloop_owncloud_email'] = $sEmail;
 		$_ENV['___rainloop_owncloud_password'] = $sDecodedPassword;

--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -1,4 +1,4 @@
-<?php
+appinfo/app.php<?php
 
 /**
  * Nextcloud - RainLoop mail plugin
@@ -36,24 +36,24 @@ if (@file_exists(__DIR__.'/app/index.php'))
 		$sEncodedPassword = '';
 
 		$sUser = OCP\User::getUser();
-    $sPasswordSalt = '';
+		$sPasswordSalt = '';
 
 		if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false))
 		{
 			$sEmail = $sUser;
-      $sPasswordSalt = $sUser;
+			$sPasswordSalt = $sUser;
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin-with-email', false))
 		{
 			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'settings', 'email','');
-      $sPasswordSalt = $sUser;
+			$sPasswordSalt = $sUser;
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
 		}
 		else
 		{
 			$sEmail = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-email', '');
-      $sPasswordSalt = $sEmail
+			$sPasswordSalt = $sEmail;
 			$sEncodedPassword = \OC::$server->getConfig()->getUserValue($sUser, 'rainloop', 'rainloop-password', '');
 		}
 

--- a/rainloop/app.php
+++ b/rainloop/app.php
@@ -1,4 +1,4 @@
-appinfo/app.php<?php
+<?php
 
 /**
  * Nextcloud - RainLoop mail plugin

--- a/rainloop/appinfo/app.php
+++ b/rainloop/appinfo/app.php
@@ -13,7 +13,7 @@ OC::$CLASSPATH['OC_RainLoop_Helper'] = OC_App::getAppPath('rainloop') . '/lib/Ra
 OCP\App::registerAdmin('rainloop', 'admin');
 OCP\App::registerPersonal('rainloop', 'personal');
 
-if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false))
+if (\OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin', false) || \OC::$server->getConfig()->getAppValue('rainloop', 'rainloop-autologin-with-email', false))
 {
 	OCP\Util::connectHook('OC_User', 'post_login', 'OC_RainLoop_Helper', 'login');
 	OCP\Util::connectHook('OC_User', 'post_setPassword', 'OC_RainLoop_Helper', 'changePassword');

--- a/rainloop/templates/admin-local.php
+++ b/rainloop/templates/admin-local.php
@@ -14,11 +14,23 @@
 			</p>
 			<br />
 			<?php endif; ?>
-			<p>      
+			<p>
 				<div style="display: flex;">
-					<input style="cursor: pointer;" type="checkbox" id="rainloop-autologin" name="rainloop-autologin" value="1" <?php if ($_['rainloop-autologin']): ?>checked="checked"<?php endif; ?> />
+					<input type="radio" id="rainloop-noautologin" name="rainloop-autologin" value="0" <?php if (!$_['rainloop-autologin']&&!$_['rainloop-autologin-with-email']): ?>checked="checked"<?php endif; ?> />
+					<label style="margin: auto 5px;" for="rainloop-noautologin">
+						<?php p($l->t('Do not automatically login')); ?>
+					</label>
+				</div>
+				<div style="display: flex;">
+					<input type="radio" id="rainloop-autologin" name="rainloop-autologin" value="1" <?php if ($_['rainloop-autologin']): ?>checked="checked"<?php endif; ?> />
 					<label style="margin: auto 5px;" for="rainloop-autologin">
 						<?php p($l->t('Automatically login with Nextcloud user credentials')); ?>
+					</label>
+				</div>
+				<div style="display: flex;">
+					<input type="radio" id="rainloop-autologin-with-email" name="rainloop-autologin" value="2" <?php if ($_['rainloop-autologin-with-email']): ?>checked="checked"<?php endif; ?> />
+					<label style="margin: auto 5px;" for="rainloop-autologin-with-email">
+						<?php p($l->t('Automatically login with Nextcloud user email credentials')); ?>
 					</label>
 				</div>
 				<br />


### PR DESCRIPTION
This is a fix to add an option in the admin panel.
Now the checkbox for automatically login users is a 3 radio buttons.
* no automatic login
* automatic login with NC credentials like user@domain
* automatic login with NC user email which can be whatever. In this case, still the NC password is used to try the login. This option is used in my case for LDAP user with an email which is on the same domain as NC but not like user@domain.
See issues #11 and #88 for more details.

The three options have been tested locally but not the "user defined email and password" in the personnal settings.

I think the way it is implemented will not break backward compatibility.

Any review/comments are welcome.

PS:the pl translation has not been updated.
PPS: I can add the Fr translation if desired.