### PR TITLE
Resolves #166 and reverts commit @f5383b8.

### DIFF
--- a/rainloop/lib/Settings/PersonalSettings.php
+++ b/rainloop/lib/Settings/PersonalSettings.php
@@ -25,17 +25,7 @@ class PersonalSettings {
 			$parameters[$k] = $v;
 		}
 
-		return new TemplateResponse('rainloop', 'personal_settings', $parameters);
-	}
-
-	public function getEmail() {
-		$uid = \OC::$server->getUserSession()->getUser()->getUID();
-		return $this->config->getUserValue($uid, 'rainloop', 'rainloop-email');
-	}
-
-	public function getPassword() {
-		$uid = \OC::$server->getUserSession()->getUser()->getUID();
-		return $this->config->getUserValue($uid, 'rainloop', 'rainloop-password');
+		return new TemplateResponse('rainloop', 'personal_settings', $parameters, '');
 	}
 
 }

--- a/rainloop/templates/personal.php
+++ b/rainloop/templates/personal.php
@@ -1,13 +1,8 @@
 <?php
 
 use OCA\RainLoop\Settings\PersonalSettings;
+
 $app = new \OCA\RainLoop\AppInfo\Application();
 $controller = $app->getContainer()->query(PersonalSettings::class);
+return $controller->getForm()->render();
 
-OCP\Util::addScript('rainloop', 'personal');
-
-$oTemplate = new OCP\Template('rainloop', 'personal_settings');
-$oTemplate->assign('rainloop-email', $controller->getEmail());
-$oTemplate->assign('rainloop-password', $controller->getPassword());
-
-return $oTemplate->fetchPage();


### PR DESCRIPTION
It turns out that the resolution to #166 was simply adding `''` [(empty single quotes) as the fourth argument](https://docs.nextcloud.com/server/13.0.0/developer_manual/api/OCP/AppFramework/Http/TemplateResponse.html#OCP\AppFramework\Http\TemplateResponse::$renderAs) to the `TemplateResponse()` in PersonalSettings.php.