### PR TITLE
Stops insecurely saving the user's NC password in the database.

### DIFF
--- a/rainloop/lib/AppInfo/Application.php
+++ b/rainloop/lib/AppInfo/Application.php
@@ -27,7 +27,8 @@ class Application extends App {
 					$c->query('AppName'),
 					$c->query('Request'),
 					$c->getServer()->getAppManager(),
-					$c->query('ServerContainer')->getConfig()
+					$c->query('ServerContainer')->getConfig(),
+					$c->getServer()->getSession()
 				);
 			}
 		);
@@ -51,7 +52,8 @@ class Application extends App {
 				return new RainLoopHelper(
 					$c->getServer()->getConfig(),
 					$c->getServer()->getUserSession(),
-					$c->getServer()->getAppManager()
+					$c->getServer()->getAppManager(),
+					$c->getServer()->getSession()
 				);
 			}
 		);

--- a/rainloop/lib/Controller/PageController.php
+++ b/rainloop/lib/Controller/PageController.php
@@ -10,18 +10,21 @@ use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\ISession;
 
 class PageController extends Controller {
 	private $userId;
 	private $config;
 	private $appManager;
 	private $appPath;
+	private $session;
 
-	public function __construct($AppName, IRequest $request, IAppManager $appManager, IConfig $config) {
+	public function __construct($AppName, IRequest $request, IAppManager $appManager, IConfig $config, ISession $session) {
 		parent::__construct($AppName, $request);
 		$this->appPath = $appManager->getAppPath('rainloop');
 		$this->config = $config;
 		$this->appManager = $appManager;
+		$this->session = $session;
 	}
 
 	/**
@@ -66,13 +69,6 @@ class PageController extends Controller {
 
 	public function app() {
 
-		$csp = new ContentSecurityPolicy();
-		// fixes object-src: 'none' which blocks chrome from preview pdf
-		$csp->addAllowedObjectDomain("'self'");
-
-		$response = new TemplateResponse('rainloop', 'app');
-		$response->setContentSecurityPolicy($csp);
-
 		RainLoopHelper::regRainLoopDataFunction();
 
 		if (isset($_GET['OwnCloudAuth'])) {
@@ -83,7 +79,7 @@ class PageController extends Controller {
 
 			if ($this->config->getAppValue('rainloop', 'rainloop-autologin', false)) {
 				$sEmail = $sUser;
-				$sEncodedPassword = $this->config->getUserValue($sUser, 'rainloop', 'rainloop-autologin-password', '');
+				$sEncodedPassword = $this->session['rainloop-autologin-password'];
 			} else {
 				$sEmail = $this->config->getUserValue($sUser, 'rainloop', 'rainloop-email', '');
 				$sEncodedPassword = $this->config->getUserValue($sUser, 'rainloop', 'rainloop-password', '');
@@ -97,7 +93,6 @@ class PageController extends Controller {
 
 		include $this->appPath . '/app/index.php';
 
-		return $response;
 	}
 
 }

--- a/rainloop/lib/Util/RainLoopHelper.php
+++ b/rainloop/lib/Util/RainLoopHelper.php
@@ -220,7 +220,11 @@ class RainLoopHelper {
 		$sPassword = $password;
 		$sEncodedPassword = self::encodePassword($sPassword, md5($sEmail));
 
-		$session['rainloop-autologin-password'] = $sEncodedPassword;
+		// Only store the user's password in the current session if they have
+		// enabled auto-login using NC credentials.
+		if ($config->getUserValue($sUser, 'rainloop', 'rainloop-autologin', '')) {
+			$session['rainloop-autologin-password'] = $sEncodedPassword;
+		}
 	}
 
 	/**

--- a/rainloop/lib/Util/RainLoopHelper.php
+++ b/rainloop/lib/Util/RainLoopHelper.php
@@ -222,7 +222,7 @@ class RainLoopHelper {
 
 		// Only store the user's password in the current session if they have
 		// enabled auto-login using NC credentials.
-		if ($config->getUserValue($sUser, 'rainloop', 'rainloop-autologin', '')) {
+		if ($config->getAppValue('rainloop', 'rainloop-autologin')) {
 			$session['rainloop-autologin-password'] = $sEncodedPassword;
 		}
 	}


### PR DESCRIPTION
Currently, an NC user's password is categorically stored insecurely in the NC database if the RainLoop app is installed, even if the user doesn't have `rainloop-autologin` enabled. Despite the fact that the password is potentially encrypted (if the user has `openssl` module in their PHP install) or base64 encoded, it almost doesn't mean anything because it's not a one-way hash. If a security vulnerability allowed an attacker access to the database, all the attacker has to do is to reverse the encryption process to get the clear text password, making the encryption seemingly somewhat useless (assuming I'm understanding all this correctly).

This PR will stop storing the user's password in the database altogether. Instead, on every login, the password will be stored (possibly encrypted) in the session, but **only** if the users has enabled auto-login (`rainloop-autologin`) using their NC credentials. The session is ephemeral storage, and the data goes away when the session is over. Additionally, it appears that Nextcloud encrypts session data, so the PHP session file on disk should contain encrypted data, not cleartext. 

This partially, though not fully, resolves #87, implementing @ohmer1's suggestions.