### PR TITLE
Allow the dot in assets path guessing.

### DIFF
--- a/app/rainloop/v/1.14.0/app/libraries/RainLoop/Utils.php
+++ b/app/rainloop/v/1.14.0/app/libraries/RainLoop/Utils.php
@@ -578,7 +578,7 @@ class Utils
 			}
 		}
 		/*Now trying to detect the apps folder to give the right URL for assets */
-		$re = '/\/([a-zA-Z0-9-_]*)\/rainloop\/app\//m';
+		$re = '/\/([a-zA-Z0-9-_\.]*)\/rainloop\/app\//m';
 		$str = __FILE__;
 		preg_match($re, $str, $matches);
 


### PR DESCRIPTION
Following on #201, the fix didn't work for me because I have a dot in my apps path (/apps.installed). 
This allows it.