### PR TITLE
Add missing primary key to rainloop_system table

### DIFF
--- a/app/rainloop/v/1.15.0/app/libraries/RainLoop/Common/PdoAbstract.php
+++ b/app/rainloop/v/1.15.0/app/libraries/RainLoop/Common/PdoAbstract.php
@@ -442,9 +442,11 @@ abstract class PdoAbstract
 			{
 				case 'mysql':
 					$aQ[] = 'CREATE TABLE IF NOT EXISTS rainloop_system (
+id bigint UNSIGNED NOT NULL AUTO_INCREMENT,
 sys_name varchar(50) NOT NULL,
 value_int int UNSIGNED NOT NULL DEFAULT 0,
 value_str varchar(128) NOT NULL DEFAULT \'\',
+PRIMARY KEY(id),
 INDEX sys_name_rainloop_system_index (sys_name)
 ) /*!40000 ENGINE=INNODB *//*!40101 CHARACTER SET utf8 COLLATE utf8_general_ci */;';
 					$aQ[] = 'CREATE TABLE IF NOT EXISTS rainloop_users (


### PR DESCRIPTION
## Description
The table `rainloop_system` is the only table without a primary key which isn't good. For databases with `pxc_strict_mode = ENFORCING or MASTER` this proves impossible to use as a Storage (PDO) and it isn't a good practice.

This PR adds a primary key to `rainloop_system` table.

Here is the error that is thrown:
<img width="851" alt="Screen Shot 2021-03-16 at 11 11 52 AM" src="https://user-images.githubusercontent.com/17147375/111323372-91fd5c80-8648-11eb-85aa-3e73032b1b33.png">


I've already opened a PR to the rainloop repo too. I'm not sure how you guys do the rainloop changes that is why I'm opening this PR here too.